### PR TITLE
feat: scale stream processing

### DIFF
--- a/camunda-orchestrator/src/main/avro/scale_event.avsc
+++ b/camunda-orchestrator/src/main/avro/scale_event.avsc
@@ -1,0 +1,9 @@
+{
+  "namespace": "com.eventdriven.healthcare.avro",
+  "type": "record",
+  "name": "MQTTScaleEvent",
+  "fields": [
+    { "name": "messageID", "type": "int" },
+    { "name": "weight", "type": "int" }
+  ]
+}

--- a/camunda-orchestrator/src/main/avro/scale_event.avsc
+++ b/camunda-orchestrator/src/main/avro/scale_event.avsc
@@ -4,6 +4,6 @@
   "name": "MQTTScaleEvent",
   "fields": [
     { "name": "messageID", "type": "int" },
-    { "name": "weight", "type": "int" }
+    { "name": "weight", "type": "float" }
   ]
 }

--- a/camunda-orchestrator/src/main/java/com/eventdriven/healthcare/camundaorchestrator/config/KafkaConsumerConfig.java
+++ b/camunda-orchestrator/src/main/java/com/eventdriven/healthcare/camundaorchestrator/config/KafkaConsumerConfig.java
@@ -82,7 +82,7 @@ public class KafkaConsumerConfig {
         return f;
     }
 
-    // Kafka Consumer for ScaleEvent
+    // Kafka Consumer for MQTTScaleEvent
     @Bean
     public ConsumerFactory<String, MQTTScaleEvent> ArvoScaleConsumerFactory() {
         Map<String, Object> props = new HashMap<>();

--- a/camunda-orchestrator/src/main/java/com/eventdriven/healthcare/camundaorchestrator/config/KafkaConsumerConfig.java
+++ b/camunda-orchestrator/src/main/java/com/eventdriven/healthcare/camundaorchestrator/config/KafkaConsumerConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import com.eventdriven.healthcare.avro.NfcEvent;
+import com.eventdriven.healthcare.avro.MQTTScaleEvent;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -57,7 +58,7 @@ public class KafkaConsumerConfig {
         return factory;
     }
 
-
+    // Kafka Consumer for NfcEvent
     @Bean
     public ConsumerFactory<String, NfcEvent> ArvoNfcConsumerFactory() {
         Map<String, Object> props = new HashMap<>();
@@ -71,13 +72,38 @@ public class KafkaConsumerConfig {
 
         return new DefaultKafkaConsumerFactory<>(props);
     }
-
+    // Kafka Listener Container Factory for NfcEvent
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, NfcEvent>
     kafkaListenerArvoNfcFactory() {
         ConcurrentKafkaListenerContainerFactory<String, NfcEvent> f =
                 new ConcurrentKafkaListenerContainerFactory<>();
         f.setConsumerFactory(ArvoNfcConsumerFactory());
+        return f;
+    }
+
+    // Kafka Consumer for ScaleEvent
+    @Bean
+    public ConsumerFactory<String, MQTTScaleEvent> ArvoScaleConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,   StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class);
+        props.put("schema.registry.url", schemaRegistryUrl);
+        props.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, true);
+
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    // Kafka Listener Container Factory for NfcEvent
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, MQTTScaleEvent>
+    kafkaListenerArvoScaleFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, MQTTScaleEvent> f =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        f.setConsumerFactory(ArvoScaleConsumerFactory());
         return f;
     }
 }

--- a/camunda-orchestrator/src/main/java/com/eventdriven/healthcare/camundaorchestrator/consumer/MessageProcessConsumer.java
+++ b/camunda-orchestrator/src/main/java/com/eventdriven/healthcare/camundaorchestrator/consumer/MessageProcessConsumer.java
@@ -83,7 +83,7 @@ public class MessageProcessConsumer {
             groupId = "${spring.kafka.consumer.group-id}")
     public void handleScaleEvent(@Payload MQTTScaleEvent event) {
         try {
-            int weight = event.getWeight();
+            float weight = event.getWeight();
             logger.info("Received load_cell event with weight: {}", weight);
 
             // Query Camunda for an execution waiting for the "Message_ScaleReading" event.
@@ -103,7 +103,7 @@ public class MessageProcessConsumer {
 
                 Map<String, Object> vars = new HashMap<>();
                 vars.put("latest_scale_value", weight);
-
+                logger.info("Correlating scale reading {} with process instance ID: {}", weight, correlationId);
                 CamundaMessageDto camundaMsg = CamundaMessageDto.builder()
                         .correlationId(correlationId)
                         .vars(vars)

--- a/camunda-orchestrator/src/main/resources/application.yaml
+++ b/camunda-orchestrator/src/main/resources/application.yaml
@@ -17,6 +17,7 @@ spring:
     patientEvents-topic: patientEvents-topic
     mqttEvents-topic: smart-healthcare-data
     nfcEvents-topic: nfc-events
+    scaleEvents-topic: scale-events
 
 rest:
     insulin-calculator-url: http://localhost:8095/calculateInsulin

--- a/scale/src/main/java/com/eventdriven/healthcare/scale/service/ScaleService.java
+++ b/scale/src/main/java/com/eventdriven/healthcare/scale/service/ScaleService.java
@@ -78,10 +78,9 @@ public class ScaleService {
         }
         Float requestedDose = cmd.getInsulinDose();
         Float scaleValue = cmd.getScaleValue();
-        Float syringeWeight = 4.0f;
 
         float doseValue = (requestedDose < 1) ? 1 : Math.round(requestedDose);
-        float doseDifference = (scaleValue - syringeWeight) - doseValue;
+        float doseDifference = scaleValue - doseValue;
 
         if (doseDifference == 0f) {
             producerService.publishInsulinDoseValidated(currentReservation.getCorrelationId(),true, 0.0f);

--- a/stream-processor/src/main/avro/scale_event.avsc
+++ b/stream-processor/src/main/avro/scale_event.avsc
@@ -1,9 +1,9 @@
 {
   "namespace": "com.eventdriven.healthcare.avro",
   "type": "record",
-  "name": "ScaleEvent",
+  "name": "MQTTScaleEvent",
   "fields": [
     { "name": "messageID", "type": "int" },
-    { "name": "weight", "type": "int" }
+    { "name": "weight", "type": "float" }
   ]
 }

--- a/stream-processor/src/main/avro/scale_event.avsc
+++ b/stream-processor/src/main/avro/scale_event.avsc
@@ -1,0 +1,9 @@
+{
+  "namespace": "com.eventdriven.healthcare.avro",
+  "type": "record",
+  "name": "ScaleEvent",
+  "fields": [
+    { "name": "messageID", "type": "int" },
+    { "name": "weight", "type": "int" }
+  ]
+}

--- a/stream-processor/src/main/java/com/eventdriven/healthcare/streamprocessor/serialization/avro/AvroSerdes.java
+++ b/stream-processor/src/main/java/com/eventdriven/healthcare/streamprocessor/serialization/avro/AvroSerdes.java
@@ -1,6 +1,7 @@
 package com.eventdriven.healthcare.streamprocessor.serialization.avro;
 
 import com.eventdriven.healthcare.avro.NfcEvent;
+import com.eventdriven.healthcare.avro.ScaleEvent;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
 import org.apache.avro.specific.SpecificRecord;
@@ -26,8 +27,7 @@ public class AvroSerdes {
     return make(url, isKey);
   }
 
-  // TODO: Uncomment when ScaleEvent is available
-  //public static Serde<ScaleEvent> scaleEvent(String url, boolean isKey) {
-  //  return make(url, isKey);
-  //}
+  public static Serde<ScaleEvent> scaleEvent(String url, boolean isKey) {
+    return make(url, isKey);
+  }
 }

--- a/stream-processor/src/main/java/com/eventdriven/healthcare/streamprocessor/serialization/avro/AvroSerdes.java
+++ b/stream-processor/src/main/java/com/eventdriven/healthcare/streamprocessor/serialization/avro/AvroSerdes.java
@@ -1,7 +1,7 @@
 package com.eventdriven.healthcare.streamprocessor.serialization.avro;
 
+import com.eventdriven.healthcare.avro.MQTTScaleEvent;
 import com.eventdriven.healthcare.avro.NfcEvent;
-import com.eventdriven.healthcare.avro.ScaleEvent;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
 import org.apache.avro.specific.SpecificRecord;
@@ -27,7 +27,7 @@ public class AvroSerdes {
     return make(url, isKey);
   }
 
-  public static Serde<ScaleEvent> scaleEvent(String url, boolean isKey) {
+  public static Serde<MQTTScaleEvent> scaleEvent(String url, boolean isKey) {
     return make(url, isKey);
   }
 }

--- a/stream-processor/src/main/java/com/eventdriven/healthcare/streamprocessor/topology/MqttTopology.java
+++ b/stream-processor/src/main/java/com/eventdriven/healthcare/streamprocessor/topology/MqttTopology.java
@@ -76,7 +76,7 @@ public class MqttTopology {
         scaleStream.print(Printed.<String, JsonNode>toSysOut().withLabel("scale-events"));
 
         KStream<String, JsonNode> eventFilteredScaleStream =
-                scaleStream.filter((k, node) -> node.get("weight").asInt() >= 1);
+                scaleStream.filter((k, node) -> node.get("weight").asInt() >= 5);
         eventFilteredScaleStream.print(Printed.<String, JsonNode>toSysOut().withLabel("event-filtered-scale-events"));
 
         KStream<String, ObjectNode> contentFilteredScaleStream =

--- a/stream-processor/src/main/java/com/eventdriven/healthcare/streamprocessor/util/ScaleFormatter.java
+++ b/stream-processor/src/main/java/com/eventdriven/healthcare/streamprocessor/util/ScaleFormatter.java
@@ -1,0 +1,11 @@
+package com.eventdriven.healthcare.streamprocessor.util;
+
+public class ScaleFormatter {
+    /**
+     * Accepts weights like "20"
+     * and returns "weight minus the weight of the syringe (5gr)"
+     */
+    public static int format(int raw) {
+        return raw - 4;
+    }
+}

--- a/stream-processor/src/main/java/com/eventdriven/healthcare/streamprocessor/util/ScaleFormatter.java
+++ b/stream-processor/src/main/java/com/eventdriven/healthcare/streamprocessor/util/ScaleFormatter.java
@@ -5,7 +5,7 @@ public class ScaleFormatter {
      * Accepts weights like "20"
      * and returns "weight minus the weight of the syringe (5gr)"
      */
-    public static int format(int raw) {
-        return raw - 4;
+    public static float format(float raw) {
+        return raw - 4f;
     }
 }


### PR DESCRIPTION
Add MQTTScaleEvent and ScaleEvent processing to Kafka consumer and st…ream processor

- Introduced MQTTScaleEvent schema in Avro format.
- Updated KafkaConsumerConfig to include a consumer factory for MQTTScaleEvent.
- Modified MessageProcessConsumer to handle MQTTScaleEvent payloads.
- Added scaleEvents-topic to application configuration.
- Implemented ScaleEvent processing in MqttTopology with filtering and formatting logic.
- Created ScaleFormatter utility for weight adjustment.